### PR TITLE
Flaky test-case fix

### DIFF
--- a/services/src/main/java/org/apache/druid/server/router/TieredBrokerHostSelector.java
+++ b/services/src/main/java/org/apache/druid/server/router/TieredBrokerHostSelector.java
@@ -43,7 +43,7 @@ import org.joda.time.DateTime;
 import org.joda.time.Interval;
 
 import java.util.Collection;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -330,7 +330,7 @@ public class TieredBrokerHostSelector
   {
     private AtomicInteger roundRobinIndex = new AtomicInteger(-1);
 
-    private Map<String, Server> nodesMap = new HashMap<>();
+    private Map<String, Server> nodesMap = new LinkedHashMap<>();
     private ImmutableList<Server> nodes = ImmutableList.of();
 
     void add(String id, Server node)


### PR DESCRIPTION
Location of flaky test: services/src/test/java/org/apache/druid/server/router/TieredBrokerHostSelectorTest/testBasicSelect

Fix in file: services/src/main/java/org/apache/druid/server/router/TieredBrokerHostSelector.java

The issue: Line 172 in `TieredBrokerHostSelectorTest.java` consists of an assert statement that compares a hard-coded string with a hostname that is fetched via a query that is executed in the previous lines. The hosts come from a HashMap called nodesMap. The test fails here because a host different than the expected host is returned. Since the HashMap implementation in Java does not guarantee the order of elements, this test fails non deterministically. This was detected using the NonDex maven plugin (more info: https://github.com/TestingResearchIllinois/NonDex).

The fix: Changing HashMap to LinkedHashMap (which maintains the insertion order) fixes this issue. Since the issue occurs while fetching the host using the `getHost()` method, this cannot be fixed in the test file and needed to be fixed in code under the test.

Command to reproduce: `mvn -pl services edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest=org.apache.druid.server.router.TieredBrokerHostSelectorTest#testBasicSelect`

